### PR TITLE
Avoid leaking vecs

### DIFF
--- a/tests/test1.rs
+++ b/tests/test1.rs
@@ -48,7 +48,7 @@ fn test1() {
     let flatten = flat_tree(&tree);
     let nodes: Vec<_> = flatten
         .into_iter()
-        .filter(|n| &n.key.filename == &current_file && n.key.fn_name.contains("::run::"))
+        .filter(|n| n.key.filename == current_file && n.key.fn_name.contains("::run::"))
         .collect();
 
     assert_eq!(nodes.len(), 2);
@@ -78,7 +78,7 @@ fn extrapolate_frame<'f>(
     frames.iter().find(|f| {
         if let Some(fn_name) = &f.fn_name {
             let fn_name = rustc_demangle::demangle(fn_name).to_string();
-            f.filename.as_ref() == Some(filename) && fn_name.contains(&wanted_fn_name)
+            f.filename.as_ref() == Some(filename) && fn_name.contains(wanted_fn_name)
         } else {
             false
         }

--- a/tests/test2.rs
+++ b/tests/test2.rs
@@ -66,7 +66,7 @@ fn test2() {
     let flatten = flat_tree(&tree);
     let nodes: Vec<_> = flatten
         .into_iter()
-        .filter(|n| &n.key.filename == &current_file && n.key.fn_name.contains("::run_"))
+        .filter(|n| n.key.filename == current_file && n.key.fn_name.contains("::run_"))
         .collect();
 
     // 2 allocations + 2 deallocations + run_child call inside run_parent
@@ -119,7 +119,7 @@ fn extrapolate_frame<'f>(
     frames.iter().find(|f| {
         if let Some(fn_name) = &f.fn_name {
             let fn_name = rustc_demangle::demangle(fn_name).to_string();
-            f.filename.as_ref() == Some(filename) && fn_name.contains(&wanted_fn_name)
+            f.filename.as_ref() == Some(filename) && fn_name.contains(wanted_fn_name)
         } else {
             false
         }


### PR DESCRIPTION
This PR avoids using Vecs and then leaking it.

Storage is initialized in a const fashion when creating the allocator, and will live in the same static address, not on the heap. This should increase performances, but I have no benchmarks to demonstrate it (I also understand that performances is not a main goal of this allocator).

I've noticed a logic flaw, and I want to discuss it with you:
* old version was recreating the storage at every `start_track`, but not resetting `allocation_logs_pointer` and `deallocation_logs_pointer`, thus if someone would have called `start_track` multiple times (obviously respecting the safety guarantees of never calling it concurrently) he could have received the overflow panic even if the buffer wasn't really full
* new version never empties the storage, thus calling `start_track` multiple times will always keep previous run in memory

A third behavior could be implemented, if desired, emptying the storage and resetting the counters, to allow multiple indepentent runs.


Unrelated, but I would also suggest to use `clippy` while developing, I've took the initiative to apply some clippy lints on first commit.